### PR TITLE
80 check for correct error handling

### DIFF
--- a/sedr/__init__.py
+++ b/sedr/__init__.py
@@ -68,7 +68,9 @@ def main() -> None:
         sedr.util.test_functions["locations_query_response"] = (
             metoceanprofilecore.tests_locations_query_response
         )
-        sedr.util.test_functions["openapi_schema"] += rodeoprofilecore.tests_openapi_schema
+        sedr.util.test_functions["openapi_schema"] += (
+            metoceanprofilecore.tests_openapi_schema
+        )
 
     if sedr.util.args and sedr.util.args.metocean_profile_insitu_observations:
         sedr.util.logger.info(

--- a/sedr/__init__.py
+++ b/sedr/__init__.py
@@ -41,6 +41,7 @@ def main() -> None:
     )
     sedr.util.test_functions["data_query_response"] = []
     sedr.util.test_functions["locations_query_response"] = []
+    sedr.util.test_functions["openapi_schema"] = []
 
     # Check if metocean profile should be auto-included
     if sedr.util.args and not sedr.util.args.metocean_profile_core:
@@ -67,6 +68,7 @@ def main() -> None:
         sedr.util.test_functions["locations_query_response"] = (
             metoceanprofilecore.tests_locations_query_response
         )
+        sedr.util.test_functions["openapi_schema"] += rodeoprofilecore.tests_openapi_schema
 
     if sedr.util.args and sedr.util.args.metocean_profile_insitu_observations:
         sedr.util.logger.info(

--- a/sedr/metoceanprofilecore10.py
+++ b/sedr/metoceanprofilecore10.py
@@ -511,6 +511,44 @@ def requirement7_12(resp: requests.Response) -> tuple[bool, str]:
         "The response document for a /locations query is valid.",
     )
 
+def requirement7_13(schema: dict) -> tuple[bool, str]:
+    """
+    RODEO EDR Profile Core
+    Version: 0.1.0
+    7.13 Error handling.
+
+    Check that the OpenAPI schema defines error handling.
+    """
+    spec_url = f"{spec_base_url}#_error_handling"
+
+    paths = schema.get("paths", {})
+    errors = ""
+
+    # C
+    for path, methods in paths.items():
+        for method, details in methods.items():
+            if not isinstance(details, dict):
+                continue
+
+            responses = details.get("responses", {})
+            for status_code, response in responses.items():
+                if status_code.startswith("4"):  # Check only 4XX status codes
+                    error_response_schema = response.get("content", {}).get("application/problem+json")
+                    if not error_response_schema:
+                        errors += (f"4XX response for {method.upper()} {path} is not valid. Should use media type 'application/problem+json'."
+                                  f"See <{spec_url}> for more info.\n"
+                                  )
+
+    if errors != "":
+        return (
+            False,
+            errors,
+        )
+    
+    return (
+        True,
+        "OpenAPI schema defines error handling for 4XX responses.",
+    )
 
 tests_landing = [requirement7_2]
 tests_conformance = []  # [requirement7_1]
@@ -527,4 +565,8 @@ tests_collection = [
 
 tests_locations_query_response = [
     requirement7_12,
+]
+
+tests_openapi_schema = [
+    requirement7_13,
 ]

--- a/sedr/metoceanprofilecore10.py
+++ b/sedr/metoceanprofilecore10.py
@@ -511,6 +511,7 @@ def requirement7_12(resp: requests.Response) -> tuple[bool, str]:
         "The response document for a /locations query is valid.",
     )
 
+
 def requirement7_13(schema: dict) -> tuple[bool, str]:
     """
     RODEO EDR Profile Core
@@ -533,22 +534,20 @@ def requirement7_13(schema: dict) -> tuple[bool, str]:
             responses = details.get("responses", {})
             for status_code, response in responses.items():
                 if status_code.startswith("4"):  # Check only 4XX status codes
-                    error_response_schema = response.get("content", {}).get("application/problem+json")
+                    error_response_schema = response.get("content", {}).get(
+                        "application/problem+json"
+                    )
                     if not error_response_schema:
-                        errors += (f"4XX response for {method.upper()} {path} is not valid. Should use media type 'application/problem+json'."
-                                  f"See <{spec_url}> for more info.\n"
-                                  )
+                        errors += (
+                            f"4XX response for {method.upper()} {path} is not valid. Media-type shall be 'application/problem+json'."
+                            f"See <{spec_url}> for more info.\n"
+                        )
 
     if errors != "":
-        return (
-            False,
-            errors,
-        )
-    
-    return (
-        True,
-        "OpenAPI schema defines error handling for 4XX responses.",
-    )
+        return (False, errors)
+
+    return (True, "OpenAPI schema defines error handling for 4XX responses.")
+
 
 tests_landing = [requirement7_2]
 tests_conformance = []  # [requirement7_1]

--- a/sedr/metoceanprofilecore10.py
+++ b/sedr/metoceanprofilecore10.py
@@ -539,14 +539,14 @@ def requirement7_13(schema: dict) -> tuple[bool, str]:
                     )
                     if not error_response_schema:
                         errors += (
-                            f"4XX response for {method.upper()} {path} is not valid. Media-type shall be 'application/problem+json'."
-                            f"See <{spec_url}> for more info.\n"
+                            f"The schema definition for 4XX responses for {method.upper()} {path} is not valid. "
+                            f"Media-type shall be 'application/problem+json'. See <{spec_url}> for more info.\n"
                         )
 
     if errors != "":
         return (False, errors)
 
-    return (True, "OpenAPI schema defines error handling for 4XX responses.")
+    return (True, "OpenAPI schema defines error handling for 4XX responses correctly.")
 
 
 tests_landing = [requirement7_2]

--- a/sedr/preflight.py
+++ b/sedr/preflight.py
@@ -46,7 +46,7 @@ def fetch_conformance(url: str, timeout: int = 10) -> tuple[bool, dict]:
         return False, conformance_json
     return True, conformance_json
 
-    
+
 def main():
     # Get landing
     landing_is_reachable, landing_json = fetch_landing(
@@ -83,7 +83,7 @@ def main():
             sedr.util.logger.debug("Test %s passed. (%s)", test_func.__name__, msg)
 
     sedr.util.logger.info("Preflight checks done.")
-    
+
     return True
 
 

--- a/sedr/preflight.py
+++ b/sedr/preflight.py
@@ -46,7 +46,7 @@ def fetch_conformance(url: str, timeout: int = 10) -> tuple[bool, dict]:
         return False, conformance_json
     return True, conformance_json
 
-
+    
 def main():
     # Get landing
     landing_is_reachable, landing_json = fetch_landing(
@@ -83,6 +83,7 @@ def main():
             sedr.util.logger.debug("Test %s passed. (%s)", test_func.__name__, msg)
 
     sedr.util.logger.info("Preflight checks done.")
+    
     return True
 
 

--- a/sedr/schemat.py
+++ b/sedr/schemat.py
@@ -63,7 +63,7 @@ def set_up_collections(landing_page_links: list) -> list:
             f"{landing_page_links}. Aborting."
         )
     try:
-        response = requests.get(collections_url, timeout=60)
+        response = requests.get(collections_url, timeout=sedr.util.args.timeout)
         response.raise_for_status()
         return response.json().get("collections", [])
     except (requests.RequestException, json.JSONDecodeError, requests.HTTPError) as err:
@@ -192,10 +192,10 @@ def test_data_query_response(id, collection):  # pylint: disable=redefined-built
 
         try:
             if queries.outside != "":
-                outside = requests.get(queries.outside, timeout=60)
+                outside = requests.get(queries.outside, timeout=sedr.util.args.timeout)
                 if outside.status_code < 400 or outside.status_code >= 500:
                     errors += f"Expected status code 4xx for query {queries.outside}; Got {outside.status_code}\n"
-            inside = requests.get(queries.inside, timeout=60)
+            inside = requests.get(queries.inside, timeout=sedr.util.args.timeout)
         except requests.exceptions.RequestException as err:
             errors += f"Request for {err.request.url} failed: {err}\n"
         if inside.status_code != 200:
@@ -221,7 +221,7 @@ def test_locations_query_response(id, collection):  # pylint: disable=redefined-
         pytest.skip("No locations query in this collection")
 
     base_url = collection_url(collection["links"])
-    resp = requests.get(urljoin(base_url, "locations"), timeout=90)
+    resp = requests.get(urljoin(base_url, "locations"), timeout=sedr.util.args.timeout)
     if resp.status_code != 200:
         pytest.fail(
             f"Expected status code 200 for query {base_url}; Got {resp.status_code}"

--- a/sedr/schemat.py
+++ b/sedr/schemat.py
@@ -196,7 +196,15 @@ def test_locations_query_response(id, collection):  # pylint: disable=redefined-
         pytest.skip("No locations query in this collection")
 
     base_url = collection_url(collection["links"])
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
     resp = requests.get(urljoin(base_url, "locations"), timeout=60)
+=======
+    resp = requests.get(urljoin(base_url, "locations"), timeout=90)
+>>>>>>> Stashed changes
+=======
+    resp = requests.get(urljoin(base_url, "locations"), timeout=90)
+>>>>>>> Stashed changes
     if resp.status_code != 200:
         pytest.fail(
             f"Expected status code 200 for query {base_url}; Got {resp.status_code}"

--- a/sedr/schemat.py
+++ b/sedr/schemat.py
@@ -79,6 +79,26 @@ schema = set_up_schemathesis(sedr.util.args, landing_page_links)
 collections = set_up_collections(landing_page_links)
 
 
+def test_openapi_schema():
+    """Test that the OpenAPI schema is correct according to the EDR profile."""
+
+     # Run edr, ogc, profile tests
+    errors = ""
+    for test_func in sedr.util.test_functions["openapi_schema"]:
+        status, msg = test_func(schema=schema.raw_schema)
+        if not status:
+            sedr.util.logger.error(
+                "Test %s failed with message: %s", test_func.__name__, msg
+            )
+
+            errors += f"Test {test_func.__name__} failed with message: {msg}\n"
+
+        sedr.util.logger.info("Test %s passed. (%s)", test_func.__name__, msg)
+
+    if errors != "":
+        raise AssertionError(errors)
+
+
 @schema.parametrize()  # parametrize => Create tests for all operations in schema
 @settings(max_examples=sedr.util.args.iterations, deadline=None)
 def test_openapi(case):
@@ -196,15 +216,7 @@ def test_locations_query_response(id, collection):  # pylint: disable=redefined-
         pytest.skip("No locations query in this collection")
 
     base_url = collection_url(collection["links"])
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-    resp = requests.get(urljoin(base_url, "locations"), timeout=60)
-=======
     resp = requests.get(urljoin(base_url, "locations"), timeout=90)
->>>>>>> Stashed changes
-=======
-    resp = requests.get(urljoin(base_url, "locations"), timeout=90)
->>>>>>> Stashed changes
     if resp.status_code != 200:
         pytest.fail(
             f"Expected status code 200 for query {base_url}; Got {resp.status_code}"

--- a/sedr/schemat.py
+++ b/sedr/schemat.py
@@ -82,7 +82,7 @@ collections = set_up_collections(landing_page_links)
 def test_openapi_schema():
     """Test that the OpenAPI schema is correct according to the EDR profile."""
 
-     # Run edr, ogc, profile tests
+    # Run edr, ogc, profile tests
     errors = ""
     for test_func in sedr.util.test_functions["openapi_schema"]:
         status, msg = test_func(schema=schema.raw_schema)

--- a/sedr/schemat.py
+++ b/sedr/schemat.py
@@ -62,7 +62,7 @@ def set_up_collections(landing_page_links: list) -> list:
             f"{landing_page_links}. Aborting."
         )
     try:
-        response = requests.get(collections_url, timeout=30)
+        response = requests.get(collections_url, timeout=60)
         response.raise_for_status()
         return response.json().get("collections", [])
     except (requests.RequestException, json.JSONDecodeError, requests.HTTPError) as err:
@@ -167,10 +167,10 @@ def test_data_query_response(id, collection):  # pylint: disable=redefined-built
 
         try:
             if queries.outside != "":
-                outside = requests.get(queries.outside, timeout=30)
+                outside = requests.get(queries.outside, timeout=60)
                 if outside.status_code < 400 or outside.status_code >= 500:
                     errors += f"Expected status code 4xx for query {queries.outside}; Got {outside.status_code}\n"
-            inside = requests.get(queries.inside, timeout=30)
+            inside = requests.get(queries.inside, timeout=60)
         except requests.exceptions.RequestException as err:
             errors += f"Request for {err.request.url} failed: {err}\n"
         if inside.status_code != 200:
@@ -196,7 +196,7 @@ def test_locations_query_response(id, collection):  # pylint: disable=redefined-
         pytest.skip("No locations query in this collection")
 
     base_url = collection_url(collection["links"])
-    resp = requests.get(urljoin(base_url, "locations"), timeout=30)
+    resp = requests.get(urljoin(base_url, "locations"), timeout=60)
     if resp.status_code != 200:
         pytest.fail(
             f"Expected status code 200 for query {base_url}; Got {resp.status_code}"

--- a/sedr/schemat.py
+++ b/sedr/schemat.py
@@ -2,6 +2,7 @@ import json
 import sys
 from urllib.parse import urljoin
 
+import warnings
 import pytest
 import requests
 import schemathesis
@@ -96,8 +97,12 @@ def test_openapi_schema():
         sedr.util.logger.info("Test %s passed. (%s)", test_func.__name__, msg)
 
     if errors != "":
-        raise AssertionError(errors)
-
+        # Use warning instead of error as default for now, as custom media-type for 4XX is currently not
+        # fully supported in frameworks like FastAPI.
+        if sedr.util.args.strict:
+            raise AssertionError(errors)
+        else:
+            warnings.warn(errors)
 
 @schema.parametrize()  # parametrize => Create tests for all operations in schema
 @settings(max_examples=sedr.util.args.iterations, deadline=None)

--- a/sedr/util.py
+++ b/sedr/util.py
@@ -68,8 +68,8 @@ def parse_args(args, version: str = "") -> argparse.Namespace:
     parser.add_argument(
         "--timeout",
         type=int,
-        default=10,
-        help="Set timeout for requests. Default 10.",
+        default=60,
+        help="Set timeout for requests. Default 60.",
     )
 
     args = parser.parse_args(args)


### PR DESCRIPTION
The idea here is that for some things, as in error handling, its easier to check for compliance by:

1. check the openapi schema (with new test function test_openapi_schema)
2. check service against schema (as already done with test_openapi).
